### PR TITLE
Replace /bin/sh with /bin/bash

### DIFF
--- a/layout/DEBIAN/extrainst_
+++ b/layout/DEBIAN/extrainst_
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ $1 == upgrade ]]; then
     /usr/bin/launchctl unload /Library/LaunchDaemons/com.1conan.cumsync.plist

--- a/layout/DEBIAN/prerm
+++ b/layout/DEBIAN/prerm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ $1 == remove || $1 == purge ]]; then
     /usr/bin/launchctl unload /Library/LaunchDaemons/com.1conan.cumsync.plist


### PR DESCRIPTION
`/bin/sh` causes errors while installing/upgrading/removing. This fixes it﻿